### PR TITLE
Use request library to support HTTPS and simplify code

### DIFF
--- a/lib/http-promise.js
+++ b/lib/http-promise.js
@@ -1,33 +1,21 @@
 var utils  = require("radiodan-client").utils,
     logger = utils.logger(__filename),
-    http   = require("http");
+    request = require("request");
 
 module.exports = { get: get };
 
 function get(uri) {
-  var requested = utils.promise.defer(),
-      dataFound = utils.promise.defer();
+  var dfd  = utils.promise.defer(),
+      opts = { encoding: "utf8", uri: uri };
 
-  http.get(uri, requested.resolve);
-
-  requested.promise.then(function(res) {
-    var body = "";
-
-    res.setEncoding("utf8");
-
-    res.on("data", function(chunk) {
-      body += chunk;
-    });
-
-    res.on("end", function() {
-      dataFound.resolve(body);
-    });
-
-    req.on("error", function(error) {
+  request(opts, function (error, response, body) {
+    if (error) {
       logger.warn(error);
-      dataFound.reject(error);
-    });
+      dfd.reject(error);
+    } else {
+      dfd.resolve(body);
+    }
   });
 
-  return dataFound.promise;
+  return dfd.promise;
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "serve-static": "^1.0.2",
     "morgan": "^1.0.0",
     "nedb": "^0.10.4",
-    "swig": "^1.3.2"
+    "swig": "^1.3.2",
+    "request": "~2.34.0"
   },
   "devDependencies": {
     "nodemon": "^1.0.15",


### PR DESCRIPTION
@pixelblend:

I'd like to be able to use the HTTPS services API URL. The [`request`](https://github.com/mikeal/request) library does this transparently and simplifies the logic.

What do you think?
