### PR TITLE
Emit power messages

### DIFF
--- a/lib/actions/announce.js
+++ b/lib/actions/announce.js
@@ -68,10 +68,15 @@ function create(players, ui, services, eventBus) {
                   clear: true, playlist: [track]
                 });
       })
-      .then(function () {
-        trigger.attach();
-        return players.announcer.play();
-      })
+      .then(
+        function () {
+          trigger.attach();
+          return players.announcer.play();
+        },
+        function () {
+          state.handle('stopAnnouncing');
+        }
+      )
       .catch(utils.failedPromiseHandler());
 
     active = true;

--- a/lib/actions/play.js
+++ b/lib/actions/play.js
@@ -23,6 +23,8 @@ function create(players, ui, services, eventBus) {
     players.announcer.clear();
     players.avoider.clear();
 
+    eventBus.emit('power', { isOn: true });
+
     return players.main.add({
       // add station
       clear: true,

--- a/lib/actions/standby.js
+++ b/lib/actions/standby.js
@@ -30,6 +30,8 @@ function create(players, ui, services, eventBus) {
 
     this.transition('standby');
 
+    eventBus.emit('power', { isOn: false });
+
     function powerLightRed() {
       return ui.RGBLEDs.power.emit({
         colour: ui.colours.red


### PR DESCRIPTION
Emit power messages over the event stream so that web UI can react even when it didn't initiate the transition (like when physical button is pressed, or another web UI).

```
event:message
data:{"topic":"power","data":{"isOn":true}}
```
