### PR TITLE
Fix bug where station is forgotten when using physical power button

### DIFF
--- a/app/radio/routes.js
+++ b/app/radio/routes.js
@@ -154,10 +154,8 @@ function routes(app, eventBus, device, services, settings) {
   function changeService(req, res) {
     var id = req.params.id;
 
-    settings.update({serviceId: id}).then(function() {
-      device.handle('play', id);
-      res.send(200);
-    });
+    device.handle('play', id);
+    res.send(200);
   }
 
   function respondWithSuccess(req, res) {

--- a/app/radio/routes.js
+++ b/app/radio/routes.js
@@ -9,6 +9,11 @@ module.exports = routes;
 function routes(app, eventBus, device, services, settings) {
   var audio = radiodan.audio.get('default');
 
+  app.post('/button', function (req, res) {
+    device.handle('power');
+    res.send(200);
+  })
+
   app.get('/next', function(req, res) {
     device.handle('playNext');
     res.send(200);

--- a/app/radio/routes.js
+++ b/app/radio/routes.js
@@ -80,7 +80,7 @@ function routes(app, eventBus, device, services, settings) {
 
     logLevel = utils.logger.logLevel ? utils.logger.logLevel() : null;
 
-    if(services.current()) {
+    if(device.state != 'standby') {
       var programme = services.programmeFor(services.current());
       current = {
         id: programme.id,

--- a/config/settings-defaults.json
+++ b/config/settings-defaults.json
@@ -12,7 +12,7 @@
     "action": null
   },
   "radio": {
-    "serviceId": "radio4",
+    "serviceId": "radio1",
     "playing":   true,
     "preferredServices": [
       "radio1", "1xtra", "radio2", "radio3",

--- a/lib/actions/play.js
+++ b/lib/actions/play.js
@@ -55,7 +55,7 @@ function create(players, ui, services, eventBus) {
     if(stationId) {
      return stationId;
     } else {
-     return services.current() || services.revert() || services.default;
+     return services.current() || services.default;
     }
   }
 }

--- a/lib/actions/play.js
+++ b/lib/actions/play.js
@@ -49,13 +49,12 @@ function create(players, ui, services, eventBus) {
 
   };
 
-  // play given service, current service,
-  // or default service
+  // play given service or current service
   function determineStation(stationId) {
     if(stationId) {
      return stationId;
     } else {
-     return services.current() || services.default;
+     return services.current();
     }
   }
 }

--- a/lib/actions/standby.js
+++ b/lib/actions/standby.js
@@ -32,8 +32,6 @@ function create(players, ui, services, eventBus) {
     players.main.clear();
     players.avoider.clear();
     players.announcer.clear();
-    // TODO: Do we have to do this?
-    services.change(null);
 
     this.transition('standby');
 

--- a/lib/services/manager.js
+++ b/lib/services/manager.js
@@ -32,7 +32,16 @@ function create(register, eventBus, settings) {
   }
 
   function change(id) {
-    var metadata;
+    var metadata,
+        err;
+
+    if (register.providerOf(id) == null) {
+      err = new Error();
+      err.name = 'ServiceDoesNotExist';
+      err.msg  = 'Service ' + id + ' does not exist';
+      err.serviceId = id;
+      throw err;
+    }
 
     history.push(currentServiceId);
 

--- a/lib/services/manager.js
+++ b/lib/services/manager.js
@@ -10,7 +10,6 @@ function create(register, eventBus, settings) {
 
   instance.change       = change;
   instance.next         = nextService;
-  instance.revert       = revert;
   instance.events       = register.events;
   // TODO: replace instances of `get` for `playlist`
   instance.get          = get;
@@ -71,13 +70,6 @@ function create(register, eventBus, settings) {
       logger.info(nextServiceId, currentIndex);
       return nextServiceId;
     }).then(null, utils.failedPromiseHandler(logger));
-  }
-
-  function revert() {
-    var last = history.pop();
-    if (last) {
-      change(last);
-    }
   }
 
   /*

--- a/lib/services/manager.js
+++ b/lib/services/manager.js
@@ -18,11 +18,21 @@ function create(register, eventBus, settings) {
   instance.all          = all;
   instance.current      = current;
 
+  instance.ready = fetchDefaultSettings();
+
   settings.get().then(updateDefaultServiceId);
-  eventBus.on('settings.radio', updateDefaultServiceId);
+  settings.on('update', updateDefaultServiceId);
 
   function updateDefaultServiceId(setData) {
     instance.default = setData.serviceId;
+  }
+
+  function fetchDefaultSettings() {
+    return settings.get()
+      .then(function (data) {
+        updateDefaultServiceId(data)
+        return utils.promise.resolve();
+      });
   }
 
   return instance;

--- a/lib/services/manager.js
+++ b/lib/services/manager.js
@@ -5,7 +5,6 @@ module.exports.create = create;
 
 function create(register, eventBus, settings) {
   var instance = {},
-      history  = [],
       currentServiceId;
 
   instance.change       = change;
@@ -20,11 +19,15 @@ function create(register, eventBus, settings) {
 
   instance.ready = fetchDefaultSettings();
 
-  settings.get().then(updateDefaultServiceId);
   settings.on('update', updateDefaultServiceId);
 
   function updateDefaultServiceId(setData) {
-    instance.default = setData.serviceId;
+    setData = setData || {}
+    if (setData.serviceId) {
+      instance.default = setData.serviceId;
+    } else {
+      instance.default = register.services()[0];
+    }
   }
 
   function fetchDefaultSettings() {
@@ -38,7 +41,7 @@ function create(register, eventBus, settings) {
   return instance;
 
   function current() {
-    return currentServiceId;
+    return currentServiceId || instance.default;
   }
 
   function change(id) {
@@ -52,8 +55,6 @@ function create(register, eventBus, settings) {
       err.serviceId = id;
       throw err;
     }
-
-    history.push(currentServiceId);
 
     currentServiceId = id;
 
@@ -73,7 +74,7 @@ function create(register, eventBus, settings) {
   function nextService() {
     return settings.get().then(function(setData) {
       var preferred    = setData.preferredServices || [],
-          currentIndex = preferred.indexOf(currentServiceId),
+          currentIndex = preferred.indexOf(instance.current()),
           nextIndex    = currentIndex + 1,
           nextServiceId;
 

--- a/lib/services/manager.js
+++ b/lib/services/manager.js
@@ -19,9 +19,12 @@ function create(register, eventBus, settings) {
   instance.all          = all;
   instance.current      = current;
 
-  settings.get().then(function(setData) {
+  settings.get().then(updateDefaultServiceId);
+  eventBus.on('settings.radio', updateDefaultServiceId);
+
+  function updateDefaultServiceId(setData) {
     instance.default = setData.serviceId;
-  });
+  }
 
   return instance;
 
@@ -38,6 +41,11 @@ function create(register, eventBus, settings) {
 
     if(currentServiceId) {
       metadata = programmeFor(currentServiceId);
+
+      settings.update({serviceId: currentServiceId}).then(
+        function() { logger.info('settings.serviceId updated to', currentServiceId); },
+        function() { logger.warn('settings.serviceId not updated to', currentServiceId); }
+      );
     }
 
     eventBus.emit('service.id', currentServiceId);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,5 +1,6 @@
 var Datastore        = require('nedb'),
     deepEqual        = require('deepequal'),
+    EventEmitter = require('eventemitter2').EventEmitter2,
     utils            = require('radiodan-client').utils,
     logger           = utils.logger(__filename),
     settingsDefaults = require('../config/settings-defaults.json');
@@ -25,7 +26,8 @@ function create(eventBus, options, myLogger) {
   }
 
   function build(namespace, defaults) {
-    var query;
+    var instance = new EventEmitter({ wildcard: true }),
+        query;
 
     if(typeof namespace !== 'string') {
       throw new Error('Namespace must be a string');
@@ -34,7 +36,12 @@ function create(eventBus, options, myLogger) {
     query = { type: namespace };
     defaults = defaults || settingsDefaults[namespace] || {};
 
-    return { type: namespace, get: get, set: set, update: update };
+    instance.type = namespace;
+    instance.get = get;
+    instance.set = set;
+    instance.update = update;
+
+    return instance;
 
     function get() {
       var getPromise = utils.promise.defer();
@@ -92,6 +99,8 @@ function create(eventBus, options, myLogger) {
     }
 
     function emitUpdate(data) {
+      instance.emit('update', data);
+
       if(eventBus) {
         var message = 'settings.' + namespace;
         eventBus.emit(message, data);

--- a/test/actions/test-play.js
+++ b/test/actions/test-play.js
@@ -8,7 +8,7 @@ describe('Play Action', function(){
 
     this.player = fakeRadiodan('player');
     this.ui     = fakeRadiodan('ui');
-    this.eventBus = { emit: sinon.spy() };
+    this.eventBus = { emit: sinon.spy(), on: sinon.spy() };
     this.subject = play.create(this.player, this.ui, this.services, this.eventBus);
 
     // lazy hack to expose underlying action function
@@ -36,24 +36,11 @@ describe('Play Action', function(){
       assert.equal(determined, stationId);
     });
 
-    it('uses the services#revert if current returns null', function(){
+    it('uses the services#default if current returns null', function(){
       var stationId = sinon.stub(),
           determined;
 
       this.services.current = function() {};
-      this.services.revert = function() {return stationId};
-
-      determined = this.subject.determineStation();
-
-      assert.equal(determined, stationId);
-    });
-
-    it('uses the services#default if revert returns null', function(){
-      var stationId = sinon.stub(),
-          determined;
-
-      this.services.current = function() {};
-      this.services.revert  = function() {};
       this.services.default = stationId;
 
       determined = this.subject.determineStation();

--- a/test/actions/test-play.js
+++ b/test/actions/test-play.js
@@ -35,18 +35,6 @@ describe('Play Action', function(){
 
       assert.equal(determined, stationId);
     });
-
-    it('uses the services#default if current returns null', function(){
-      var stationId = sinon.stub(),
-          determined;
-
-      this.services.current = function() {};
-      this.services.default = stationId;
-
-      determined = this.subject.determineStation();
-
-      assert.equal(determined, stationId);
-    });
   });
 
   describe('playing a station', function() {

--- a/test/lib/test-services-manager.js
+++ b/test/lib/test-services-manager.js
@@ -40,6 +40,20 @@ describe('Services Manager', function() {
     });
   });
 
+  it('current returns default service from settings on creation', function(done) {
+
+    this.settings.get = function () {
+      return utils.promise.resolve({ serviceId: 'koolfm' });
+    };
+
+    var subject = ServicesManager.create(
+      this.register, this.eventBus, this.settings);
+
+    subject.ready.then(function () {
+      assert.equal(subject.current(), 'koolfm');
+    })
+    .then(done, done);
+  });
 
   it('emits new service on eventBus', function() {
     var eventMock = sinon.spy(),

--- a/test/lib/test-services-manager.js
+++ b/test/lib/test-services-manager.js
@@ -5,7 +5,10 @@ describe('Services Manager', function() {
   beforeEach(function() {
     this.register = {metadata: function() {}};
     this.eventBus = new EventEmitter();
-    this.settings = {get: function(){ return utils.promise.resolve({})}};
+    this.settings = {
+      get: function(){ return utils.promise.resolve({})},
+      update: function(){ return utils.promise.resolve({})}
+    };
   });
 
   it('changes current service', function() {
@@ -22,7 +25,7 @@ describe('Services Manager', function() {
   it('emits new service on eventBus', function() {
     var eventMock = sinon.spy(),
         subject = ServicesManager.create(
-          this.register, {emit: eventMock}, this.settings);
+          this.register, {emit: eventMock, on: sinon.stub()}, this.settings);
 
     subject.change('radio3');
     assert.deepEqual(['service.id', 'radio3'], eventMock.args[0]);
@@ -34,7 +37,7 @@ describe('Services Manager', function() {
         registerMock = sinon.stub().returns(metadataMock),
         subject = ServicesManager.create(
             {metadata: registerMock},
-            {emit: eventMock}, this.settings);
+            {emit: eventMock, on: sinon.stub()}, this.settings);
 
     subject.change('my-music');
     assert.deepEqual(['my-music'], registerMock.args[0]);
@@ -45,7 +48,7 @@ describe('Services Manager', function() {
     var preferredServices = ['radio1', 'radio2', 'radio3'],
         servicesMock = sinon.stub().returns(
           utils.promise.resolve({preferredServices: preferredServices})),
-        settings = {get: servicesMock},
+        settings = {get: servicesMock, update: this.settings.update},
         subject = ServicesManager.create(
           this.register, this.eventBus, settings);
 

--- a/test/lib/test-services-manager.js
+++ b/test/lib/test-services-manager.js
@@ -62,18 +62,4 @@ describe('Services Manager', function() {
       })
     .then(done, done);
   });
-
-  it('reverts to previous service', function(){
-    var subject = ServicesManager.create(
-      this.register, this.eventBus, this.settings);
-
-    subject.change('radio1');
-    assert.equal(subject.current(), 'radio1');
-
-    subject.change('radio2');
-    assert.equal(subject.current(), 'radio2');
-
-    subject.revert();
-    assert.equal(subject.current(), 'radio1');
-  });
 });

--- a/test/lib/test-services-manager.js
+++ b/test/lib/test-services-manager.js
@@ -3,7 +3,7 @@ var ServicesManager = require(libDir + 'services/manager'),
 
 describe('Services Manager', function() {
   beforeEach(function() {
-    this.register = {metadata: function() {}};
+    this.register = {metadata: function() {}, providerOf: function () { return {}; }};
     this.eventBus = new EventEmitter();
     this.settings = {
       get: function(){ return utils.promise.resolve({})},
@@ -22,6 +22,24 @@ describe('Services Manager', function() {
     assert.equal(subject.current(), 'my-music');
   });
 
+  it('throws if service doesn\'t exist', function() {
+    var subject = ServicesManager.create(
+      this.register, this.eventBus, this.settings);
+
+    this.register.providerOf = function () {
+      return undefined;
+    };
+
+    assert.throws(function () {
+      subject.change(null);
+    });
+
+    assert.throws(function () {
+      subject.change('my-80s-music');
+    });
+  });
+
+
   it('emits new service on eventBus', function() {
     var eventMock = sinon.spy(),
         subject = ServicesManager.create(
@@ -35,8 +53,12 @@ describe('Services Manager', function() {
     var eventMock = sinon.spy(),
         metadataMock = sinon.stub(),
         registerMock = sinon.stub().returns(metadataMock),
-        subject = ServicesManager.create(
-            {metadata: registerMock},
+        subject;
+
+    this.register.metadata = registerMock;
+
+    subject = ServicesManager.create(
+            this.register,
             {emit: eventMock, on: sinon.stub()}, this.settings);
 
     subject.change('my-music');


### PR DESCRIPTION
This fixes a couple of issues that were causing the last service not to be remembered when the radio was put into standby and powered on again via the physical UI (tested and working on a running device).

The service id was only stored in settings when the station was changed via HTTP API. Now, any call to `ServiceManager#change` will store.

The `ServiceManager#default` property was loaded with the `serviceId` from settings on creation but wasn't tracking changes to the `serviceId`. It now subscribes to change events and updates `default` so it reflects that service id in settings. I found this to be easier to understand than `ServiceManager.revert()` because of the way `nulls` can be stored in the history array which are then ignored by revert.

Tests have been updated to reflect the changes, mainly ensuring that `settings` and `eventBus` are stubbed correctly.

Happy to discuss further if this isn't a great way to solve this.
